### PR TITLE
feat: add support for member expression keys

### DIFF
--- a/src/utils/comparer.ts
+++ b/src/utils/comparer.ts
@@ -49,6 +49,30 @@ const compareProperty = <
     const rKey = r.key.name
     // Both string should compare in alphabetical order
     return lKey === rKey ? 0 : lKey < rKey ? -1 : 1
+  } else if (
+    l.key.type === AST_NODE_TYPES.MemberExpression &&
+    r.key.type === AST_NODE_TYPES.MemberExpression &&
+    l.key.object.type === AST_NODE_TYPES.Identifier &&
+    r.key.object.type === AST_NODE_TYPES.Identifier &&
+    (l.key.property.type === AST_NODE_TYPES.Identifier || l.key.property.type === AST_NODE_TYPES.PrivateIdentifier) &&
+    (r.key.property.type === AST_NODE_TYPES.Identifier || r.key.property.type === AST_NODE_TYPES.PrivateIdentifier)
+  ) {
+    // Computed key should place at right side (ex: { [obj.KEY]: value })
+    if (l.computed !== r.computed) {
+      return l.computed ? 1 : -1
+    }
+
+    // First compare object name
+    const lObject = l.key.object.name
+    const rObject = r.key.object.name
+    if (lObject !== rObject) {
+      return lObject < rObject ? -1 : 1
+    }
+
+    // Then compare property name
+    const lKey = l.key.property.name
+    const rKey = r.key.property.name
+    return lKey === rKey ? 0 : lKey < rKey ? -1 : 1
   } else {
     // Other types should sort as [AST_NODE_TYPES.Literal, AST_NODE_TYPES.Identifier, AST_NODE_TYPES.MemberExpression, others]
     const lOrder = getAstNodeTypeOrder(l.key.type)

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,8 @@ function noNeedModifyCases() {
   enum Type {
     A = 'A',
     B = 'B',
+    C = 'C',
+    D = 'D',
   }
 
   // @sort
@@ -43,10 +45,14 @@ function noNeedModifyCases() {
     b: 'b',
     [A]: 'A',
     [B]: 'B',
+    [Type.C]: 'C',
+    [Type.D]: 'D',
   }
 
   // @sort-keys:reversed
   const reversedObject = {
+    [Type.D]: 'D',
+    [Type.C]: 'C',
     [B]: 'B',
     [A]: 'A',
     b: 'b',
@@ -77,10 +83,14 @@ function noNeedModifyCases() {
     b: string
     [A]: string
     [B]: string
+    [Type.C]: string
+    [Type.D]: string
   }
 
   // @sort-keys:reversed
   interface ReversedMockInterface {
+    [Type.D]: string
+    [Type.C]: string
     [B]: string
     [A]: string
     b: string
@@ -98,6 +108,8 @@ function needLintCases() {
   enum Type {
     A = 'A',
     B = 'B',
+    C = 'C',
+    D = 'D',
   }
 
   // @sort
@@ -131,6 +143,8 @@ function needLintCases() {
   const object = {
     [B]: 'B',
     [A]: 'A',
+    [Type.D]: 'D',
+    [Type.C]: 'C',
     b: 'b',
     a: 'a',
     '22': '22',
@@ -149,6 +163,8 @@ function needLintCases() {
     b: 'b',
     [A]: 'A',
     [B]: 'B',
+    [Type.D]: 'D',
+    [Type.C]: 'C',
   }
 
   /*
@@ -171,6 +187,8 @@ function needLintCases() {
     '2': string
     '11': string
     '1': string
+    [Type.D]: string
+    [Type.C]: string
   }
 
   // @sort-keys:reversed
@@ -183,5 +201,7 @@ function needLintCases() {
     b: string
     [A]: string
     [B]: string
+    [Type.C]: string
+    [Type.D]: string
   }
 }

--- a/tests/sort-keys-annotation-default.test.ts
+++ b/tests/sort-keys-annotation-default.test.ts
@@ -84,6 +84,21 @@ ruleTester.run('sort-keys-annotation', rule, {
       `,
       filename: getFilename('main.ts'),
     },
+    {
+      code: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys
+      const object = { [AKeys.A]: string, [AKeys.B]: string, [BKeys.B]: string, [BKeys.B]: string, }
+      `,
+      filename: getFilename('main.ts'),
+    },
   ],
   invalid: [
     {
@@ -199,6 +214,34 @@ ruleTester.run('sort-keys-annotation', rule, {
         [A]: string
         [B]: string
       }
+      `,
+      filename: getFilename('main.ts'),
+    },
+    {
+      code: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys
+      const object = { [AKeys.A]: string, [BKeys.A]: string, [AKeys.B]: string, [BKeys.B]: string, }
+      `,
+      errors: [{ messageId: HAS_UNSORTED_KEYS_MESSAGE_ID, type: AST_NODE_TYPES.ObjectExpression }],
+      output: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys
+      const object = { [AKeys.A]: string, [AKeys.B]: string, [BKeys.A]: string, [BKeys.B]: string, }
       `,
       filename: getFilename('main.ts'),
     },

--- a/tests/sort-keys-annotation-default.test.ts
+++ b/tests/sort-keys-annotation-default.test.ts
@@ -62,6 +62,8 @@ ruleTester.run('sort-keys-annotation', rule, {
         b: 'b',
         [A]: 'A',
         [B]: 'B',
+        [Type.C]: 'C',
+        [Type.D]: 'D',
       }
       `,
       filename: getFilename('main.ts'),
@@ -80,6 +82,8 @@ ruleTester.run('sort-keys-annotation', rule, {
         b: string
         [A]: string
         [B]: string
+        [Type.C]: string
+        [Type.D]: string
       }
       `,
       filename: getFilename('main.ts'),
@@ -155,6 +159,8 @@ ruleTester.run('sort-keys-annotation', rule, {
       const B = 'B'
       // @sort-keys
       const object = {
+        [Type.D]: 'D',
+        [Type.C]: 'C',
         [B]: 'B',
         [A]: 'A',
         b: 'b',
@@ -179,6 +185,8 @@ ruleTester.run('sort-keys-annotation', rule, {
         b: 'b',
         [A]: 'A',
         [B]: 'B',
+        [Type.C]: 'C',
+        [Type.D]: 'D',
       }
       `,
       filename: getFilename('main.ts'),
@@ -189,6 +197,8 @@ ruleTester.run('sort-keys-annotation', rule, {
       const B = 'B'
       // @sort-keys
       interface MockInterface {
+        [Type.D]: string
+        [Type.C]: string
         [B]: string
         [A]: string
         b: string
@@ -213,6 +223,8 @@ ruleTester.run('sort-keys-annotation', rule, {
         b: string
         [A]: string
         [B]: string
+        [Type.C]: string
+        [Type.D]: string
       }
       `,
       filename: getFilename('main.ts'),

--- a/tests/sort-keys-annotation-reversed.test.ts
+++ b/tests/sort-keys-annotation-reversed.test.ts
@@ -56,6 +56,21 @@ ruleTester.run('sort-keys-annotation', rule, {
       `,
       filename: getFilename('main.ts'),
     },
+    {
+      code: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys:reversed
+      const object = { [BKeys.B]: string, [BKeys.A]: string, [AKeys.B]: string, [AKeys.A]: string, }
+      `,
+      filename: getFilename('main.ts'),
+    },
   ],
   invalid: [
     {
@@ -123,6 +138,34 @@ ruleTester.run('sort-keys-annotation', rule, {
         '11': string
         '1': string
       }
+      `,
+      filename: getFilename('main.ts'),
+    },
+    {
+      code: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys:reversed
+      const object = { [AKeys.A]: string, [BKeys.A]: string, [AKeys.B]: string, [BKeys.B]: string, }
+      `,
+      errors: [{ messageId: HAS_UNSORTED_KEYS_MESSAGE_ID, type: AST_NODE_TYPES.ObjectExpression }],
+      output: `
+      enum AKeys {
+        A = 'A',
+        B = 'B',
+      }
+      enum BKeys {
+        A = 'A',
+        B = 'B',
+      }
+      // @sort-keys:reversed
+      const object = { [BKeys.B]: string, [BKeys.A]: string, [AKeys.B]: string, [AKeys.A]: string, }
       `,
       filename: getFilename('main.ts'),
     },


### PR DESCRIPTION
This adds support for keys that are member expressions, which is common when working with enums.

Fixes #8